### PR TITLE
Add link to reference docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ See the details of developing [logs](./docs/dev_logs.md).
 See more details, including system dependencies, python requirements and setups in [install.md](./docs/install.md).
 Please follows the instructions in [install.md](./docs/install.md) to install this firstly.
 
+## Reference Docs
+https://docs.contour.so/iPERDance/iPERCore/getting-started
+
 ## Run demos
 
 ### 1. Run on Google Colab 


### PR DESCRIPTION
Hi there!

My name is Leo, a CS student at Brown building an automated platform for editable codebase documentation.

I generated documentation for this repository and placed a link in the README. Please feel free to try it out and let me know what you think!